### PR TITLE
feat: Add custom slug support

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,6 +109,78 @@ describe('URL Shortener API', () => {
       expect(mockKV.put).toHaveBeenCalled()
     })
 
+    it('should create a short URL with a custom slug', async () => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: 'my_custom-slug' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(201)
+
+      const json = await res.json() as any
+      expect(json.slug).toBe('my_custom-slug')
+      expect(json.short_url).toBe('http://localhost/my_custom-slug')
+      expect(json.stats_url).toBe('http://localhost/api/stats/my_custom-slug')
+      expect(mockKV.put).toHaveBeenCalledWith('my_custom-slug', 'https://example.com')
+    })
+
+    it('should return 409 when custom slug already exists', async () => {
+      mockKV._store.set('takenSlug', 'https://already.example')
+
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: 'takenSlug' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(409)
+      const json = await res.json() as any
+      expect(json.error).toBe('Slug already in use')
+    })
+
+    it('should return 400 for invalid custom slug format', async () => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: 'invalid!' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(400)
+      const json = await res.json() as any
+      expect(json.error).toBe('Invalid slug')
+    })
+
+    it.each(['api', 'stats'])('should return 400 for reserved slug "%s"', async (reserved) => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: reserved })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(400)
+      const json = await res.json() as any
+      expect(json.error).toBe('Slug is reserved')
+    })
+
+    it('should still generate a random slug when none is provided (regression)', async () => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(201)
+      const json = await res.json() as any
+      expect(json.slug).toMatch(/^[a-zA-Z0-9]{6}$/)
+      expect(json.short_url).toMatch(/^http:\/\/localhost\/[a-zA-Z0-9]{6}$/)
+    })
+
     it('should return 400 when URL is missing', async () => {
       const req = createRequest('POST', '/api/shorten', {})
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,14 @@ const isBot = (userAgent: string | undefined): boolean => {
   return botPattern.test(userAgent);
 }
 
+const isValidCustomSlug = (slug: string): boolean => {
+  const trimmed = slug.trim()
+  if (trimmed.length < 3 || trimmed.length > 30) return false
+  return /^[a-zA-Z0-9-_]+$/.test(trimmed)
+}
+
+const RESERVED_SLUGS = new Set(['api', 'stats'])
+
 /**
  * POST /api/shorten
  * Creates a short URL from a long URL.
@@ -33,10 +41,42 @@ const isBot = (userAgent: string | undefined): boolean => {
  */
 app.post('/api/shorten', async (c) => {
   try {
-    const { url } = await c.req.json()
+    const { url, slug: requestedSlug } = await c.req.json()
     
     if (!url) {
       return c.json({ error: 'URL is required' }, 400)
+    }
+
+    if (typeof requestedSlug !== 'undefined') {
+      if (typeof requestedSlug !== 'string') {
+        return c.json({ error: 'Invalid slug' }, 400)
+      }
+
+      const trimmed = requestedSlug.trim()
+
+      if (!isValidCustomSlug(trimmed)) {
+        return c.json({ error: 'Invalid slug' }, 400)
+      }
+
+      if (RESERVED_SLUGS.has(trimmed.toLowerCase())) {
+        return c.json({ error: 'Slug is reserved' }, 400)
+      }
+
+      const existing = await c.env.URL_DB.get(trimmed)
+      if (existing) {
+        return c.json({ error: 'Slug already in use' }, 409)
+      }
+
+      await c.env.URL_DB.put(trimmed, url)
+
+      const workerUrl = new URL(c.req.url).origin
+
+      return c.json({
+        original_url: url,
+        short_url: `${workerUrl}/${trimmed}`,
+        stats_url: `${workerUrl}/api/stats/${trimmed}`,
+        slug: trimmed
+      }, 201)
     }
 
     let slug: string = "";


### PR DESCRIPTION
## Summary
Bu PR ile user'ların random generated ID yerine kendi belirledikleri **custom slug**'ları kullanabilmesi sağlandı. İlgili issue: #1

## Changes
- **Endpoint Update:** `POST /api/shorten` endpoint'i `optional` bir `slug` parametresini kabul edecek şekilde güncellendi.
- **Validation:** Girilen slug için regex kontrolü (`^[a-zA-Z0-9-_]+$`) ve length limit eklendi.
- **Conflict Handling:** Girilen slug zaten mevcutsa `409 Conflict` hatası döndüren logic kuruldu.
- **Reserved Keywords:** Sistem tarafından kullanılan (`api`, `stats` vb.) keyword'lerin slug olarak alınması engellendi.
- **Unit Tests:** Success, conflict, invalid format ve reserved keyword case'lerini kapsayacak şekilde testler güncellendi.

## Checklist
- [x] Code build oluyor ve çalışıyor.
- [x] Yeni feature için unit test'ler yazıldı.
- [x] Mevcut random generation logic'i bozulmadı.

Closes #1