### PR TITLE
feat: Add real-time webhook notifications

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import app from './index'
 
 // Mock KV Namespace
@@ -72,7 +72,12 @@ describe('URL Shortener API', () => {
     mockKV = createMockKV()
     mockD1 = createMockD1()
     mockExecutionCtx = createMockExecutionCtx()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('ok', { status: 200 })))
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   const createRequest = (method: string, path: string, body?: object, headers?: Record<string, string>) => {
@@ -238,6 +243,79 @@ describe('URL Shortener API', () => {
       expect(res.headers.get('Location')).toBe('https://example.com')
     })
 
+    it('should send a webhook notification on redirect (success)', async () => {
+      mockKV._store.set('abc123', 'https://example.com')
+      const fetchMock = globalThis.fetch as any
+
+      const req = createRequest('GET', '/abc123', undefined, {
+        'User-Agent': 'Mozilla/5.0',
+        'CF-Connecting-IP': '1.2.3.4',
+        'CF-IPCountry': 'US'
+      })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(301)
+      expect(res.headers.get('Location')).toBe('https://example.com')
+
+      // Ensure async work finished
+      await mockExecutionCtx.waitUntil.mock.calls[0][0]
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      const [url, init] = fetchMock.mock.calls[0] as any
+      expect(url).toBe(
+        'https://api.clay.com/v3/sources/webhook/pull-in-data-from-a-webhook-f3df05af-88e7-429a-a6a1-474187ec2b1f'
+      )
+      expect(init.method).toBe('POST')
+      expect(init.headers).toEqual(
+        expect.objectContaining({
+          'Content-Type': 'application/json'
+        })
+      )
+
+      const payload = JSON.parse(init.body)
+      expect(payload).toEqual(
+        expect.objectContaining({
+          slug: 'abc123',
+          url: 'https://example.com',
+          ip: '1.2.3.4',
+          country: 'US',
+          user_agent: 'Mozilla/5.0'
+        })
+      )
+      expect(payload.is_bot).toBe(false)
+      expect(typeof payload.timestamp).toBe('string')
+    })
+
+    it('should not fail redirect if webhook rejects (resilience)', async () => {
+      mockKV._store.set('abc123', 'https://example.com')
+      const fetchMock = globalThis.fetch as any
+      fetchMock.mockRejectedValueOnce(new Error('webhook down'))
+
+      const req = createRequest('GET', '/abc123', undefined, {
+        'User-Agent': 'Mozilla/5.0',
+        'CF-Connecting-IP': '1.2.3.4',
+        'CF-IPCountry': 'US'
+      })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(301)
+      expect(res.headers.get('Location')).toBe('https://example.com')
+
+      // Ensure async work finished (and error was handled)
+      await mockExecutionCtx.waitUntil.mock.calls[0][0]
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
     it('should return 404 for non-existent slug', async () => {
       const req = createRequest('GET', '/nonexistent')
       
@@ -269,6 +347,7 @@ describe('URL Shortener API', () => {
 
     it('should detect bot user agents', async () => {
       mockKV._store.set('abc123', 'https://example.com')
+      const fetchMock = globalThis.fetch as any
       
       const req = createRequest('GET', '/abc123', undefined, {
         'User-Agent': 'Googlebot/2.1',
@@ -287,6 +366,11 @@ describe('URL Shortener API', () => {
       expect(mockD1.prepare).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO analytics')
       )
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [, init] = fetchMock.mock.calls[0] as any
+      const payload = JSON.parse(init.body)
+      expect(payload.is_bot).toBe(true)
     })
   })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,6 +109,78 @@ describe('URL Shortener API', () => {
       expect(mockKV.put).toHaveBeenCalled()
     })
 
+    it('should create a short URL with a custom slug', async () => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: 'my_custom-slug' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(201)
+
+      const json = await res.json() as any
+      expect(json.slug).toBe('my_custom-slug')
+      expect(json.short_url).toBe('http://localhost/my_custom-slug')
+      expect(json.stats_url).toBe('http://localhost/api/stats/my_custom-slug')
+      expect(mockKV.put).toHaveBeenCalledWith('my_custom-slug', 'https://example.com')
+    })
+
+    it('should return 409 when custom slug already exists', async () => {
+      mockKV._store.set('takenSlug', 'https://already.example')
+
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: 'takenSlug' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(409)
+      const json = await res.json() as any
+      expect(json.error).toBe('Slug already in use')
+    })
+
+    it('should return 400 for invalid custom slug format', async () => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: 'invalid!' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(400)
+      const json = await res.json() as any
+      expect(json.error).toBe('Invalid slug')
+    })
+
+    it.each(['api', 'stats'])('should return 400 for reserved slug "%s"', async (reserved) => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com', slug: reserved })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(400)
+      const json = await res.json() as any
+      expect(json.error).toBe('Slug is reserved')
+    })
+
+    it('should still generate a random slug when none is provided (regression)', async () => {
+      const req = createRequest('POST', '/api/shorten', { url: 'https://example.com' })
+
+      const res = await app.fetch(req, {
+        URL_DB: mockKV,
+        DB: mockD1
+      }, mockExecutionCtx)
+
+      expect(res.status).toBe(201)
+      const json = await res.json() as any
+      expect(json.slug).toMatch(/^[a-zA-Z0-9]{6}$/)
+      expect(json.short_url).toMatch(/^http:\/\/localhost\/[a-zA-Z0-9]{6}$/)
+    })
+
     it('should return 400 when URL is missing', async () => {
       const req = createRequest('POST', '/api/shorten', {})
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@ const isValidCustomSlug = (slug: string): boolean => {
 
 const RESERVED_SLUGS = new Set(['api', 'stats'])
 
+const CLAY_WEBHOOK_URL =
+  'https://api.clay.com/v3/sources/webhook/pull-in-data-from-a-webhook-f3df05af-88e7-429a-a6a1-474187ec2b1f'
+
 /**
  * POST /api/shorten
  * Creates a short URL from a long URL.
@@ -144,6 +147,30 @@ app.get('/:slug', async (c) => {
       await c.env.DB.prepare(
         `INSERT INTO analytics (slug, ip, country, user_agent, is_bot) VALUES (?, ?, ?, ?, ?)`
       ).bind(slug, ip, country, userAgent, botStatus).run()
+
+      try {
+        await fetch(CLAY_WEBHOOK_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            slug,
+            url: longUrl,
+            ip,
+            country,
+            user_agent: userAgent,
+            is_bot: botStatus === 1,
+            timestamp: new Date().toISOString()
+          })
+        })
+      } catch (err) {
+        console.error(
+          'Webhook notification failed',
+          { webhookUrl: CLAY_WEBHOOK_URL, slug, url: longUrl },
+          err
+        )
+      }
       
     } catch (err) {
       console.error('Analytics logging failed:', err)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,14 @@ const isBot = (userAgent: string | undefined): boolean => {
   return botPattern.test(userAgent);
 }
 
+const isValidCustomSlug = (slug: string): boolean => {
+  const trimmed = slug.trim()
+  if (trimmed.length < 3 || trimmed.length > 30) return false
+  return /^[a-zA-Z0-9-_]+$/.test(trimmed)
+}
+
+const RESERVED_SLUGS = new Set(['api', 'stats'])
+
 /**
  * POST /api/shorten
  * Creates a short URL from a long URL.
@@ -33,10 +41,42 @@ const isBot = (userAgent: string | undefined): boolean => {
  */
 app.post('/api/shorten', async (c) => {
   try {
-    const { url } = await c.req.json()
+    const { url, slug: requestedSlug } = await c.req.json()
     
     if (!url) {
       return c.json({ error: 'URL is required' }, 400)
+    }
+
+    if (typeof requestedSlug !== 'undefined') {
+      if (typeof requestedSlug !== 'string') {
+        return c.json({ error: 'Invalid slug' }, 400)
+      }
+
+      const trimmed = requestedSlug.trim()
+
+      if (!isValidCustomSlug(trimmed)) {
+        return c.json({ error: 'Invalid slug' }, 400)
+      }
+
+      if (RESERVED_SLUGS.has(trimmed.toLowerCase())) {
+        return c.json({ error: 'Slug is reserved' }, 400)
+      }
+
+      const existing = await c.env.URL_DB.get(trimmed)
+      if (existing) {
+        return c.json({ error: 'Slug already in use' }, 409)
+      }
+
+      await c.env.URL_DB.put(trimmed, url)
+
+      const workerUrl = new URL(c.req.url).origin
+
+      return c.json({
+        original_url: url,
+        short_url: `${workerUrl}/${trimmed}`,
+        stats_url: `${workerUrl}/api/stats/${trimmed}`,
+        slug: trimmed
+      }, 201)
     }
 
     let slug: string = "";


### PR DESCRIPTION
## Summary
Bu PR ile `GET /:slug` endpoint'inde redirect gerçekleşirken arka planda (**async**) event datalarının bir webhook'a (Clay) gönderilmesi sağlandı. Bu sayede redirect latency'si artmadan real-time automation tetiklenebilecek. İlgili issue: #2

## Changes
- **Async Execution:** Webhook request'i `c.executionCtx.waitUntil` içine alındı. Kullanıcı redirect olurken işlem **non-blocking** olarak arka planda devam ediyor.
- **Payload Structure:** Gönderilen JSON body'sine `slug`, `url`, `ip`, `country`, `user_agent`, `timestamp` ve bot filtrelemesi için kritik olan **`is_bot`** field'ı eklendi.
- **Error Handling:** Webhook call, redirect akışını bozmaması için `try/catch` bloğuna alındı (Fail-safe).
- **Unit Tests:** `global.fetch` mocklanarak webhook'un doğru parametreler ve payload ile tetiklendiğini doğrulayan testler yazıldı/güncellendi.

## Verification
- **Manual Testing:** Clay entegrasyonu canlı ortamda test edildi. Redirect gerçekleştiği anda datanın Clay'e başarıyla ulaştığı ve parse edilebildiği doğrulandı.
- **Bot Detection:** `is_bot` flag'inin doğru gönderildiği kontrol edildi.
- **Performance:** Webhook isteğinin redirect hızını etkilemediği gözlemlendi.

## Checklist
- [x] Code build oluyor.
- [x] Unit testler (mock fetch) başarıyla geçiyor.
- [x] Canlı test (Clay integration) yapıldı ve doğrulandı.

Closes #2