### PR TITLE
fix: prevent bot traffic from triggering webhook notifications

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -375,7 +375,7 @@ describe('URL Shortener API', () => {
       expect(mockExecutionCtx.waitUntil).toHaveBeenCalled()
     })
 
-    it('should detect bot user agents', async () => {
+    it('should detect bot user agents and skip webhook notification', async () => {
       mockKV._store.set('abc123', 'https://example.com')
       const fetchMock = globalThis.fetch as any
       
@@ -394,14 +394,13 @@ describe('URL Shortener API', () => {
       // Wait for async analytics logging
       await mockExecutionCtx.waitUntil.mock.calls[0][0]
       
+      // Database logging should still happen for bots
       expect(mockD1.prepare).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO analytics')
       )
 
-      expect(fetchMock).toHaveBeenCalledTimes(1)
-      const [, init] = fetchMock.mock.calls[0] as any
-      const payload = JSON.parse(init.body)
-      expect(payload.is_bot).toBe(true)
+      // Webhook should NOT be called for bot traffic
+      expect(fetchMock).toHaveBeenCalledTimes(0)
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,33 +146,35 @@ app.get('/:slug', async (c) => {
         `INSERT INTO analytics (slug, ip, country, user_agent, is_bot) VALUES (?, ?, ?, ?, ?)`
       ).bind(slug, ip, country, userAgent, botStatus).run()
 
-      // Optional webhook notification
-      const webhookUrl = c.env.CLAY_WEBHOOK_URL
-      if (!webhookUrl) {
-        console.warn('CLAY_WEBHOOK_URL not set, skipping webhook notification')
-      } else {
-        try {
-          await fetch(webhookUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-              slug,
-              url: longUrl,
-              ip,
-              country,
-              user_agent: userAgent,
-              is_bot: botStatus === 1,
-              timestamp: new Date().toISOString()
+      // Optional webhook notification (only for non-bot traffic)
+      if (botStatus === 0) {
+        const webhookUrl = c.env.CLAY_WEBHOOK_URL
+        if (!webhookUrl) {
+          console.warn('CLAY_WEBHOOK_URL not set, skipping webhook notification')
+        } else {
+          try {
+            await fetch(webhookUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                slug,
+                url: longUrl,
+                ip,
+                country,
+                user_agent: userAgent,
+                is_bot: botStatus === 1,
+                timestamp: new Date().toISOString()
+              })
             })
-          })
-        } catch (err) {
-          console.error(
-            'Webhook notification failed',
-            { webhookUrl, slug, url: longUrl },
-            err
-          )
+          } catch (err) {
+            console.error(
+              'Webhook notification failed',
+              { webhookUrl, slug, url: longUrl },
+              err
+            )
+          }
         }
       }
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ app.get('/:slug', async (c) => {
                 ip,
                 country,
                 user_agent: userAgent,
-                is_bot: botStatus === 1,
+                is_bot: false,
                 timestamp: new Date().toISOString()
               })
             })


### PR DESCRIPTION
## Özet
Bu değişiklik ile bot trafiğinin (crawler, spider vb.) webhook bildirimlerini tetiklemesi engellendi. Böylece Clay kotasının gereksiz dolması ve bildirim kanalındaki gürültünün azaltılması hedeflendi.

## Değişiklikler
- `index.ts` dosyasına webhook isteği atılmadan önce `botStatus` kontrolü eklendi.
- **Not:** İstatistiklerin doğru kalması adına veritabanı loglaması (D1) botlar dahil tüm trafik için çalışmaya devam ediyor.

## İlgili Issue
Closes #6